### PR TITLE
feat/msw 어드민 상품 삭제, 및 노출 비노출 수정 API 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,8 @@ const App = () => {
     useEffect(() => {
         // msw example
         // baseURL https:/fruitte.co/api
+
+        // 상품 상세 조회 ID 값에 따라 데이터와 id값 다르게 반환
         axios
             .get('https:/fruitte.co/api/goods/5')
             .then(response => console.log('goodsDetail', response))
@@ -16,6 +18,7 @@ const App = () => {
                 throw new Error(err);
             });
 
+        // 상품 전체 조회 page 값에 따라 page 데이터 다르게 반환
         axios
             .get('https:/fruitte.co/api/goods?page=5')
             .then(response => console.log('goodsAll', response))
@@ -24,9 +27,28 @@ const App = () => {
                 throw new Error(err);
             });
 
+        // 어드민 상품 상세조회  page 값에 따라 page 데이터 다르게 반환
         axios
             .get('https:/fruitte.co/api/admin/goods?page=5')
             .then(response => console.log('admin', response))
+            .catch(err => {
+                console.error(err);
+                throw new Error(err);
+            });
+
+        // 어드민 상품 노출 수정 req.body에 노출 수정값 0[비노출],1[노출]을 보내면 해당 값 그대로 반환
+        axios
+            .put('https:/fruitte.co/api/admin/goods/:goodsId/showflag', { showFlag: 0 })
+            .then(response => console.log('show', response))
+            .catch(err => {
+                console.error(err);
+                throw new Error(err);
+            });
+
+        // 어드민 상품 삭제 주소에 삭제 id 값을 보내면 삭제값 그대로 반환
+        axios
+            .delete('https:/fruitte.co/api/admin/goods/:5')
+            .then(response => console.log('delete', response))
             .catch(err => {
                 console.error(err);
                 throw new Error(err);

--- a/src/components/common/layout/adminLayout/side/list/sideList.js
+++ b/src/components/common/layout/adminLayout/side/list/sideList.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretDown, faCaretUp, faV } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
 import { useCallback } from 'react';
 
 const SideList = () => {

--- a/src/components/common/layout/adminLayout/side/profile/sideProfile.js
+++ b/src/components/common/layout/adminLayout/side/profile/sideProfile.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleUser } from '@fortawesome/free-solid-svg-icons';
+
 const SideProfile = () => {
     return (
         <ProfileTemplate>

--- a/src/mocks/adminHandler.js
+++ b/src/mocks/adminHandler.js
@@ -22,7 +22,16 @@ export const AdminHandler = [
                     soldFlag: faker.datatype.number({ min: 0, max: 1 }),
                 })),
         };
-
         return res(ctx.json(dummyProdAll));
+    }),
+
+    rest.delete('https:/fruitte.co/api/admin/goods/:goodsId', (req, res, ctx) => {
+        const goodsId = req.params.goodsId;
+        return res(ctx.json(goodsId));
+    }),
+
+    rest.put('https:/fruitte.co/api/admin/goods/:goodsId/showflag', (req, res, ctx) => {
+        const { showFlag } = req.body;
+        return res(ctx.json(showFlag));
     }),
 ];

--- a/src/pages/admin/loginPage.js
+++ b/src/pages/admin/loginPage.js
@@ -1,6 +1,4 @@
-import AdminLayout from '../../components/common/layout/adminLayout/adminLayout';
-
 const AdminLoginPage = () => {
-    return <AdminLayout>:)</AdminLayout>;
+    return ':)';
 };
 export default AdminLoginPage;

--- a/src/pages/admin/prodListPage.js
+++ b/src/pages/admin/prodListPage.js
@@ -1,0 +1,4 @@
+const AdminProdListPage = () => {
+    return ':)';
+};
+export default AdminProdListPage;

--- a/src/pages/admin/prodPage.js
+++ b/src/pages/admin/prodPage.js
@@ -1,0 +1,4 @@
+const AdminProdPage = () => {
+    return ':)';
+};
+export default AdminProdPage;

--- a/src/router.js
+++ b/src/router.js
@@ -1,15 +1,24 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import AdminLoginPage from './pages/admin/loginPage';
+import AdminProdListPage from './pages/admin/prodListPage';
+import AdminProdPage from './pages/admin/prodPage';
 import GlobalStyle from './styles/global';
+import AdminRoute from './utils/adminRoute';
 
 const Router = () => {
     return (
-        <BrowserRouter>
-            <GlobalStyle />
-            <Routes>
-                <Route path="/admin" element={<AdminLoginPage />} />
-            </Routes>
-        </BrowserRouter>
+        <>
+            <BrowserRouter>
+                <GlobalStyle />
+                <Routes>
+                    <Route element={<AdminRoute />}>
+                        <Route path="/admin" element={<AdminLoginPage />} />
+                        <Route exact path="/admin/prodList" element={<AdminProdListPage />} />
+                        <Route exact path="/admin/prod" element={<AdminProdPage />} />
+                    </Route>
+                </Routes>
+            </BrowserRouter>
+        </>
     );
 };
 export default Router;

--- a/src/utils/adminRoute.js
+++ b/src/utils/adminRoute.js
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import AdminLayout from '../components/common/layout/adminLayout/adminLayout';
+
+const AdminRoute = () => {
+    return (
+        <AdminLayout>
+            <Outlet />
+        </AdminLayout>
+    );
+};
+export default AdminRoute;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

msw의 상품 노출,비노출 수정 api와 삭제 api를 추가하였습니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. msw 상품 노출 수정
어드민 상품 노출 수정 req.body에 노출 수정값 0[비노출],1[노출]을 보내면 해당 값 그대로 반환

2. msw 상품 삭제
3어드민 상품 삭제 주소에 삭제 id 값을 보내면 삭제값 그대로 반환

<br />

## :: 기타 질문 및 특이 사항

혹시 더 추가로 만들어야하는 API를 말씀해주시면 해당 부분에 맞게 추가하겠습니다.
